### PR TITLE
Improve build system for AVX2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           - x86_64-linux-nowallet
           - x86_64-macos
           - x86_64-win
+          - x86_64-linux-experimental
         include:
           - name: i686-linux
             host: i686-pc-linux-gnu
@@ -103,6 +104,14 @@ jobs:
             config-opts: "--enable-gui=qt5 --enable-reduce-exports"
             goal: deploy
             sdk: 10.11
+          - name: x86_64-linux-experimental
+            host: x86_64-unknown-linux-gnu
+            os: ubuntu-20.04
+            packages: bc python3-zmq
+            run-tests: true
+            dep-opts: "AVX2=1"
+            config-opts: "--with-intel-avx2 --enable-gui=qt5 --enable-zmq --enable-glibc-back-compat --enable-reduce-exports"
+            goal: install
 
     runs-on: ${{ matrix.os }}
 

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -6,6 +6,7 @@ SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
 NO_WALLET ?=
 NO_UPNP ?=
+AVX2 ?=
 FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
 
 BUILD = $(shell ./config.guess)
@@ -92,12 +93,17 @@ $(host_arch)_$(host_os)_id_string+=$(shell $(host_STRIP) --version 2>/dev/null)
 qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages)
 wallet_packages_$(NO_WALLET) = $(wallet_packages)
 upnp_packages_$(NO_UPNP) = $(upnp_packages)
+avx2_packages_$(AVX2) = $(avx2_$(host_arch)_$(host_os)_packages)
 
-packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
+packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(avx2_packages_1) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 
 ifneq ($(qt_packages_),)
 native_packages += $(qt_native_packages)
+endif
+
+ifneq ($(avx2_packages_1),)
+native_packages += $(avx2_native_packages)
 endif
 
 all_packages = $(packages) $(native_packages)

--- a/depends/packages/intel-ipsec-mb.mk
+++ b/depends/packages/intel-ipsec-mb.mk
@@ -4,16 +4,16 @@ $(package)_download_path=https://github.com/intel/intel-ipsec-mb/archive/refs/ta
 $(package)_file_name=v$($(package)_version).tar.gz
 $(package)_sha256_hash=03501aea472d3c8fdf8f1f207816eefeaf5e4ebbdc71d88dcb26b2519841bb74
 $(package)_patches=remove_digest_init.patch
-$(package)_dependencies=nasm
+$(package)_dependencies=native_nasm
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/remove_digest_init.patch
 endef
 
 define $(package)_build_cmds
-  $(MAKE) NASM=$(host_prefix)/bin/nasm
+  $(MAKE) NASM=$(build_prefix)/bin/nasm
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) NASM=$(host_prefix)/bin/nasm PREFIX=$($(package)_staging_prefix_dir) SHARED=n NOLDCONFIG=y install
+  $(MAKE) NASM=$(build_prefix)/bin/nasm PREFIX=$($(package)_staging_prefix_dir) SHARED=n NOLDCONFIG=y install
 endef

--- a/depends/packages/native_nasm.mk
+++ b/depends/packages/native_nasm.mk
@@ -1,11 +1,11 @@
-package=nasm
+package=native_nasm
 $(package)_version=2.15.05
 $(package)_download_path=http://nasm.us/pub/nasm/releasebuilds/$($(package)_version)
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
+$(package)_file_name=nasm-$($(package)_version).tar.bz2
 $(package)_sha256_hash=3c4b8339e5ab54b1bcb2316101f8985a5da50a3f9e504d43fa6f35668bee2fd0
 
 define $(package)_config_cmds
-  ./configure --prefix=$(host_prefix)
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmds
@@ -14,4 +14,8 @@ endef
 
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf share 
 endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,9 +1,6 @@
 packages:=boost openssl libevent zeromq
 native_packages := native_ccache
 
-x86_64_linux_native_packages:=native_nasm
-x86_64_linux_packages:=intel-ipsec-mb
-
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf zlib
 
@@ -16,6 +13,9 @@ qt_mingw32_packages=qt
 wallet_packages=bdb
 
 upnp_packages=miniupnpc
+
+avx2_native_packages:=native_nasm
+avx2_x86_64_linux_packages:=intel-ipsec-mb
 
 darwin_native_packages = native_biplist native_ds_store native_mac_alias
 

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,5 +1,8 @@
-packages:=boost openssl libevent zeromq nasm intel-ipsec-mb
+packages:=boost openssl libevent zeromq
 native_packages := native_ccache
+
+x86_64_linux_native_packages:=native_nasm
+x86_64_linux_packages:=intel-ipsec-mb
 
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf zlib


### PR DESCRIPTION
Recommended improvements to the build system for dogecoin#2491, 

1. Make `nasm` a clean "native" dependency rather than a regular dependency, and extend the arch/os guard to the depends system. Native dependencies are built to compile on the build environment rather than the target arch/os. (also, clean up the staged dependency)
2. Make the AVX2 dependency optional and selectable, so that it does not interfere with the release process. Introduces a make flag for the depends system `AVX2=1` to select the `intel-ipsec-mb` package (and `native_nasm`)
3. Create a new CI target to build experimental features.